### PR TITLE
Add a utility script to clear all the faults

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,6 +3,7 @@ BUILT_SOURCES=generated.cpp extra_ifaces.cpp gen_serialization.hpp
 CLEANFILES=$(BUILT_SOURCES)
 
 bin_PROGRAMS = phosphor-inventory
+bin_SCRIPTS = scripts/clear-all-fault-leds.sh
 noinst_LTLIBRARIES = libmanagercommon.la libmanager.la
 
 extra_yamldir=$(YAML_PATH)/extra_interfaces.d

--- a/pimgen.py
+++ b/pimgen.py
@@ -571,7 +571,7 @@ class Everything(Renderer):
 
         for y in yaml_files:
             # parse only phosphor dbus related interface files
-            if not y.startswith('xyz'):
+            if not (y.startswith('xyz') or y.startswith('com/ibm/ipzvpd')):
                 continue
             with open(os.path.join(targetdir, y)) as fd:
                 i = y.replace('.interface.yaml', '').replace(os.sep, '.')

--- a/scripts/clear-all-fault-leds.sh
+++ b/scripts/clear-all-fault-leds.sh
@@ -1,0 +1,68 @@
+#!/bin/sh
+
+# This shell script sets the group D-Bus objects in
+# /xyz/openbmc_project/State/Decorator/OperationalStatusManager
+# to true or false.
+
+usage()
+{
+    echo "clear-all-fault-leds.sh [true/false]"
+    echo "Example: clear-all-fault-leds.sh true"
+    echo "Example: clear-all-fault-leds.sh false bmc_booted power_on _fault"
+    return 0;
+}
+
+# We need at least 1 argument
+if [ $# -lt 1 ]; then
+    echo "At least ONE argument needed";
+    usage;
+    exit 1;
+fi
+
+# User passed in argument [true/false]
+action=$1
+
+# If it is not "true" or "false", exit
+if [ "$action" != "true" ] && [ "$action" != "false" ]; then
+    echo "Bad argument $action passed";
+    usage;
+    exit 1;
+fi
+
+# Get the excluded groups, where $@ is all the agruments passed
+index=2;
+excluded_groups=""
+
+for arg in "$@"
+do
+   if [ "$arg" = "$action" ]
+   then
+       # Must be true/false
+       continue
+   #This allows accepting and using own positional parameters either via
+   #argument passing or via envrironment file.
+   elif [ $index -eq $# ]
+   then
+       excluded_groups="${excluded_groups}$arg"
+   else
+       excluded_groups="${excluded_groups}$arg|"
+   fi
+   index=$((index+1))
+done
+
+# Now, set the OperationalStatus Functional to what has been requested
+if [ ${#excluded_groups} -eq 0 ]
+then
+    for line in $(busctl tree xyz.openbmc_project.Inventory.Manager  | grep -e motherboard/ | awk -F 'xyz' '{print "/xyz" $2}');
+    do
+        busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action";
+    done
+else
+    for line in $(busctl tree xyz.openbmc_project.Inventory.Manager | grep -e motherboard/ | grep -Ev "$excluded_groups" | awk -F 'xyz' '{print "/xyz" $2}');
+    do
+        busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action";
+    done
+fi
+
+# Return Success
+exit 0


### PR DESCRIPTION
Signed-off-by: Lakshminarayana R. Kammath <lkammath@in.ibm.com>

Clear Fault LEDs during PowerOn

This shell script takes care of 

1> Listing all the inventory D-Bus objects implementing xyz.openbmc_project.State.Decorator.OperationalStatus
2> For each of those : set Functional property to true/false 

The Shell script gets called in all places where the led-set-all-groups-asserted.sh is getting called using a service file

For more details please refer https://github.com/ibm-openbmc/dev/issues/3228
