### PR TITLE
LED: App to Remove critical association that is set with Chassis

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,8 +1,8 @@
-BUILT_SOURCES=generated.cpp extra_ifaces.cpp gen_serialization.hpp
+BUILT_SOURCES=generated.cpp extra_ifaces.cpp gen_serialization.hpp 
 
 CLEANFILES=$(BUILT_SOURCES)
 
-bin_PROGRAMS = phosphor-inventory
+bin_PROGRAMS = phosphor-inventory remove-association
 noinst_LTLIBRARIES = libmanagercommon.la libmanager.la
 
 extra_yamldir=$(YAML_PATH)/extra_interfaces.d
@@ -11,6 +11,10 @@ base_yamldir=$(YAML_PATH)
 phosphor_inventory_SOURCES = app.cpp
 phosphor_inventory_LDADD = libmanager.la $(SDBUSPLUS_LIBS)
 phosphor_inventory_CXXFLAGS = $(SDBUSPLUS_CFLAGS) -flto
+
+remove_association_SOURCES = remove_association.cpp remove_association_main.cpp 
+remove_association_LDADD =  $(SDBUSPLUS_LIBS)
+remove_association_CXXFLAGS = $(SDBUSPLUS_CFLAGS)
 
 libmanagercommon_la_LDFLAGS = -static
 libmanagercommon_la_SOURCES = \

--- a/remove_association.cpp
+++ b/remove_association.cpp
@@ -1,0 +1,111 @@
+/**
+ * Copyright © 2021 IBM Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "config.h"
+
+#include "remove_association.hpp"
+
+#include <cstdlib>
+#include <iostream>
+
+namespace phosphor
+{
+namespace inventory
+{
+namespace manager
+{
+
+constexpr auto mapperBus = "xyz.openbmc_project.ObjectMapper";
+constexpr auto mapperObj = "/xyz/openbmc_project/object_mapper";
+constexpr auto mapperIntf = "xyz.openbmc_project.ObjectMapper";
+constexpr auto propIntf = "org.freedesktop.DBus.Properties";
+
+using AssociationTuple = std::tuple<std::string, std::string, std::string>;
+using AssociationsProperty = std::vector<AssociationTuple>;
+
+DBusSubtree getInventoryAssociations(sdbusplus::bus::bus& bus,
+                                     const std::string& objectPath,
+                                     int32_t depth)
+{
+    auto mapperCall =
+        bus.new_method_call(mapperBus, mapperObj, mapperIntf, "GetSubTree");
+
+    mapperCall.append(objectPath, depth,
+                      std::vector<std::string>(
+                          {"xyz.openbmc_project.Association.Definitions"}));
+
+    auto reply = bus.call(mapperCall);
+    DBusSubtree response;
+    try
+    {
+        reply.read(response);
+    }
+    catch (const sdbusplus::exception::exception& e)
+    {
+        log<level::ERR>("Failed to parse existing callouts subtree message",
+                        entry("ERROR=%s", e.what()),
+                        entry("REPLY_SIG=%s", reply.get_signature()));
+    }
+
+    return response;
+}
+
+void getProperty(sdbusplus::bus::bus& bus, const std::string& service,
+                 const std::string& objectPath, const std::string& interface,
+                 const std::string& property, DBusValue& value)
+{
+
+    auto method = bus.new_method_call(service.c_str(), objectPath.c_str(),
+                                      propIntf, "Get");
+    method.append(interface, property);
+    auto reply = bus.call(method);
+
+    reply.read(value);
+}
+
+void removeCriticalAssociation(sdbusplus::bus::bus& bus,
+                               const std::string& objectPath,
+                               const std::string& service)
+{
+    DBusValue getAssociationValue;
+
+    getProperty(bus, service, objectPath,
+                "xyz.openbmc_project.Association.Definitions", "Associations",
+                getAssociationValue);
+
+    auto association = std::get<AssociationsProperty>(getAssociationValue);
+
+    AssociationTuple critAssociation{
+        "health_rollup", "critical",
+        "/xyz/openbmc_project/inventory/system/chassis"};
+
+    auto it =
+        std::find(association.begin(), association.end(), critAssociation);
+    if (it != association.end())
+    {
+        association.erase(it);
+        DBusValue setAssociationValue = association;
+
+        auto method = bus.new_method_call(service.c_str(), objectPath.c_str(),
+                                          propIntf, "Set");
+
+        method.append("xyz.openbmc_project.Association.Definitions",
+                      "Associations", setAssociationValue);
+        bus.call(method);
+    }
+}
+} // namespace manager
+} // namespace inventory
+} // namespace phosphor

--- a/remove_association.hpp
+++ b/remove_association.hpp
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <phosphor-logging/log.hpp>
+#include <sdbusplus/bus.hpp>
+#include <sdbusplus/bus/match.hpp>
+
+#include <map>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace phosphor
+{
+namespace inventory
+{
+namespace manager
+{
+
+using namespace phosphor::logging;
+using DBusValue = std::variant<
+    std::string, bool, std::vector<uint8_t>, std::vector<std::string>,
+    std::vector<std::tuple<std::string, std::string, std::string>>>;
+using DBusInterface = std::string;
+using DBusService = std::string;
+using DBusInterfaceList = std::vector<DBusInterface>;
+using DBusObjectPath = std::string;
+using DBusSubtree =
+    std::map<DBusObjectPath, std::map<DBusService, std::vector<DBusInterface>>>;
+
+/**
+ * @brief Wrapper for the 'Get' properties method call
+ *
+ * @param[in] bus - The sdbusplus bus object for making D-Bus calls
+ * @param[in] service - The D-Bus service to call it on
+ * @param[in] objectPath - The D-Bus object path
+ * @param[in] interface - The interface to get the property on
+ * @param[in] property - The property name
+ * @param[out] value - Filled in with the property value.
+ */
+void getProperty(sdbusplus::bus::bus& bus, const std::string& service,
+                 const std::string& objectPath, const std::string& interface,
+                 const std::string& property, DBusValue& value);
+
+/**
+ * @brief Get subtree from the object mapper to get inventory associations
+ *
+ * @param[in] bus - The sdbusplus bus object for making D-Bus calls
+ * @param[in] path - The root of the tree to search.
+ * @param[in] depth - The number of path elements to descend.
+ */
+DBusSubtree getInventoryAssociations(sdbusplus::bus::bus& bus,
+                                     const std::string& path, int32_t depth);
+
+/**
+ * @brief Removes the critical association on the D-Bus object.
+ *
+ * @param[in] bus - The sdbusplus bus object for making D-Bus calls
+ * @param[in] objectPath - The D-Bus object path
+ * @param[in] service - The D-Bus service to call it on
+ */
+void removeCriticalAssociation(sdbusplus::bus::bus& bus,
+                               const std::string& objectPath,
+                               const std::string& service);
+
+} // namespace manager
+} // namespace inventory
+} // namespace phosphor

--- a/remove_association_main.cpp
+++ b/remove_association_main.cpp
@@ -1,0 +1,16 @@
+#include "remove_association.hpp"
+
+int main(int, char*[])
+{
+    using namespace phosphor::inventory::manager;
+    auto bus = sdbusplus::bus::new_default();
+    DBusSubtree objTree =
+        getInventoryAssociations(bus, "/xyz/openbmc_project/inventory", 0);
+    for (auto const& object : objTree)
+    {
+        const auto& objPath = object.first;
+        const auto& service = object.second.begin()->first;
+        removeCriticalAssociation(bus, objPath, service);
+    }
+    return 0;
+}


### PR DESCRIPTION
Creating critical association is being done for the items
in callouts that need their service indicators turned on
in its code, and that the other association endpoint
is the chasis so it can be used for health rollup.

The associations property on the
xyz.openbmc_project.Association.Definitions interface
will have following entry added to called out object path:
["health_rollup", "critical",
"/xyz/openbmc_project/inventory/system/chassis"]

This app will be called when bmc_booted, power_on or on _fault
to remove the critical association and this will be done called
through service

Tested:
busctl call xyz.openbmc_project.Logging /xyz/openbmc_project/logging xyz.openbmc_project.Logging.Create Create ssa{ss} xyz.openbmc_project.Common.Error.Timeout xyz.openbmc_project.Logging.Entry.Level.Error 2 "TIMEOUT_IN_MSEC" "5" "CALLOUT_INVENTORY_PATH" /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1 xyz.openbmc_project.Association.Definitions Associations
a(sss) 2 "fault_led_group" "fault_inventory_object" "/xyz/openbmc_project/led/groups/cpu0_fault" "health_rollup" "critical" "/xyz/openbmc_project/inventory/system/chassis"

./remove-association

busctl get-property xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory/system/chassis/motherboard/dcm0/cpu1 xyz.openbmc_project.Association.Definitions Associations
a(sss) 1 "fault_led_group" "fault_inventory_object" "/xyz/openbmc_project/led/groups/cpu0_fault"

Resolves 2nd requirement requirement of removing critical associations ->  of https://github.com/ibm-openbmc/dev/issues/3228

Signed-off-by: Lakshminarayana R. Kammath <lkammath@in.ibm.com>