### PR TITLE
PIM: Support deleteObject

### DIFF
--- a/manager.cpp
+++ b/manager.cpp
@@ -26,6 +26,7 @@
 #include <iostream>
 
 using namespace std::literals::chrono_literals;
+using std::filesystem::directory_iterator;
 
 namespace phosphor
 {
@@ -247,8 +248,11 @@ void Manager::updateObjects(
             newObj = true;
         }
 
-        updateInterfaces(absPath, objit->second, refit, newObj,
-                         restoreFromCache);
+        if (!objit->second.empty())
+        {
+            updateInterfaces(absPath, objit->second, refit, newObj,
+                             restoreFromCache);
+        }
 #ifdef CREATE_ASSOCIATIONS
         if (!_associations.pendingCondition() && newObj)
         {
@@ -272,8 +276,105 @@ void Manager::updateObjects(
     }
 }
 
+void Manager::clearPersistency(const std::vector<std::string>& paths)
+{
+    for (const auto& objPath : paths)
+    {
+        std::string absObjPath(std::string(PIM_PERSIST_PATH) +
+                               "/xyz/openbmc_project/inventory");
+        absObjPath.append(objPath);
+
+        for (const auto& file : directory_iterator(absObjPath))
+        {
+            // Remove files and empty subdirectories.
+            if (!remove(file.path()))
+                std::cerr << "Error deleting this file/subdir [" << file.path()
+                          << "]\n";
+        }
+
+        // All files are deleted.
+        // Now delete directory if nothing exists in this path.
+        if (remove(absObjPath.c_str()))
+        {
+            std::cerr << "Error deleting this object path- "
+                      << absObjPath.c_str() << "\n";
+        }
+    }
+}
+
+void Manager::deleteObjects(
+    std::map<sdbusplus::message::object_path, Object>& objs)
+{
+    auto objItr = objs.begin();
+    auto refItr = _refs.begin();
+    std::string absPath(_root);
+    std::vector<std::string> paths;
+
+    auto lastKey = objs.rbegin()->first;
+    auto thisIsLastObj = false;
+
+    while (objItr != objs.end())
+    {
+        // Find the insertion point or the object to DELETE.
+        refItr = lower_bound(refItr, _refs.end(), objItr->first,
+                             compareFirst(RelPathCompare(_root)));
+
+        absPath.append(objItr->first);
+
+        if (refItr == _refs.end() || refItr->first != absPath)
+        {
+            // requested object to delete not found/already deleted.
+            ++objItr;
+            continue;
+        }
+        else
+        {
+            // check if it has interfaces, if no then collect the object to
+            // delete and also remove it from object map
+            if (objItr->second.empty())
+            {
+                if (objItr->first == lastKey)
+                {
+                    thisIsLastObj = true;
+                }
+
+                paths.push_back(objItr->first);
+                objItr = objs.erase(objItr);
+
+                // In case last object from map is erased, then we can't access
+                // that map's iterator anymore. So break the loop.
+                if (thisIsLastObj)
+                {
+                    break;
+                }
+            }
+            else
+            {
+                ++objItr;
+                continue;
+            }
+        }
+    }
+
+    // If got something to delete.
+    if (paths.size())
+    {
+        // convert it to char* to call destroyObjects
+        std::vector<const char*> pathVec;
+        for (auto& p : paths)
+        {
+            pathVec.push_back(p.c_str());
+        }
+        destroyObjects(pathVec);
+
+        // Remove it from persistency also.
+        clearPersistency(paths);
+    }
+}
+
 void Manager::notify(std::map<sdbusplus::message::object_path, Object> objs)
 {
+    deleteObjects(objs);
     updateObjects(objs);
 }
 

--- a/manager.hpp
+++ b/manager.hpp
@@ -94,6 +94,17 @@ class Manager final : public ServerObject<ManagerIface>
         const std::map<sdbusplus::message::object_path, Object>& objs,
         bool restoreFromCache = false);
 
+    /** @brief Delete objects on DBus.
+     *
+     *  @param[in] objs - Map of object path and empty interface.
+     *      Empty interface will cause that corresponding object path
+     *      to be deleted from dbus tree as well as persistency path.
+     */
+    void deleteObjects(std::map<sdbusplus::message::object_path, Object>& objs);
+
+    /** @brief delete object's interfaces from persistency path*/
+    void clearPersistency(const std::vector<std::string>& paths);
+
     /** @brief Restore persistent inventory items */
     void restore();
 


### PR DESCRIPTION
PIM: Support deleteObject

This commit adds an interface deleteObject which is being used
to remove the object on dBus if FRU is removed from the system.
Also, that object directory and it's files removed from persistency.

Test Result-
Tested for Pcie_card10 as only this has connectors and ports both, on rain127.

------------------------------------------------------------------------------------------------------
Initial output-

root@rain127bmc:/tmp# busctl tree xyz.openbmc_project.Inventory.Manager |grep "pcie_card10"
            │ └─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10
            │   ├─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector0
            │   ├─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector1
            │   ├─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector2
            │   ├─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector3
            │   ├─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_bot
            │   └─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_top

root@rain127bmc:/tmp# ls /var/lib/phosphor-inventory-manager/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector0
xyz.openbmc_project.Inventory.Item.Connector
root@rain127bmc:/tmp#

--------------------------------------------------------------------------------------------------------
After Patch applied-

./ibm-read-vpd -f /sys/bus/i2c/drivers/at24/11-0050/eeprom
Running Alpana's patch
DBG: forcing ccin to pose it as cxp_prts
DBG: remove ["/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector0"]  from dbus tree and persistency
DBG: remove ["/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector1"]  from dbus tree and persistency
DBG: remove ["/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector2"]  from dbus tree and persistency
DBG: remove ["/system/chassis/motherboard/pcieslot10/pcie_card10/c10_connector3"]  from dbus tree and persistency

-----------------------------------------------------------------------------------------------------
Connectors removed from dbus-
root@rain127bmc:/tmp# busctl tree xyz.openbmc_project.Inventory.Manager |grep "pcie_card10"
            │ └─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10
            │   ├─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_bot
            │   └─/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/cxp_top

Connectors(Dir) and it's interfaces(file) removed from persistency-
root@rain127bmc:/tmp# ls /var/lib/phosphor-inventory-manager/xyz/openbmc_project/inventory/system/chassis/motherboard/pcieslot10/pcie_card10/
com.ibm.ipzvpd.Location                                xyz.openbmc_project.Inventory.Decorator.Asset          xyz.openbmc_project.Inventory.Item.PCIeDevice
com.ibm.ipzvpd.VINI                                    xyz.openbmc_project.Inventory.Decorator.I2CDevice      xyz.openbmc_project.Object.Enable
com.ibm.ipzvpd.VMPU                                    xyz.openbmc_project.Inventory.Decorator.LocationCode   xyz.openbmc_project.State.Decorator.OperationalStatus
cxp_bot                                                xyz.openbmc_project.Inventory.Item
cxp_top                                                xyz.openbmc_project.Inventory.Item.FabricAdapter

Signed-off-by: Alpana Kumari <alpankum@in.ibm.com>
Change-Id: I0dcc149b0ce7ef7f0d1742c0fbf7aabdc4ed5714