### PR TITLE
Do not clear fault leds during warm reboot

### DIFF
--- a/scripts/clear-all-fault-leds.sh
+++ b/scripts/clear-all-fault-leds.sh
@@ -29,6 +29,14 @@ if [ "$action" != "true" ] && [ "$action" != "false" ]; then
     exit 1;
 fi
 
+# Skip running this script if the chassis is powered ON.
+current_chassis_status=$(busctl get-property xyz.openbmc_project.State.Chassis /xyz/openbmc_project/state/chassis0 xyz.openbmc_project.State.Chassis CurrentPowerState | cut -d" " -f2)
+
+if [ "${current_chassis_status}" = "\"xyz.openbmc_project.State.Chassis.PowerState.On\"" ]; then
+    echo "Current chassis power state is , $current_chassis_status . Exit clear-all-fault-leds.sh script successfully without doing any fault LED reset."
+    exit 0
+fi
+
 # Get the excluded groups, where $@ is all the agruments passed
 index=2;
 excluded_groups=""


### PR DESCRIPTION
This commit has some changes in clear-all-fault-leds.sh script
to work in such a way that the script exits successfully without
resetting any fault leds whenever there is a graceful/force
warm reboot request. As during the warm reboot the chassis power
isn't turned off and so the data about fault leds should not be reset.

Test:
Tested on the following cases.
1. During a Graceful warm reboot request => Expected not to reset any
   fault leds and exit successfully.
2. During a Force warm reboot request => Expected not to reset any fault
   leds and exit successfully.
3. During a reset-reload => Expected not to reset any fault leds.
4. During a host hard reboot => Expected to reset fault leds and exit
   successfully.

The test runs as expected for all the mentioned 4 cases.
Journal log:

May 09 09:47:46 ever10bmc systemd[1]: Starting Clears all fault LED to true and remove critical associations...
May 09 09:47:46 ever10bmc systemd[1]: Starting Set the Asserted property of all the LED groups to false...
May 09 09:47:46 ever10bmc obmc-clear-all-fault-leds-and-remove-crit-association[1457]: Inside clear-all-faults-led.sh file
May 09 09:47:46 ever10bmc systemd[1]: Starting Clear the Volatile PNOR partitions in host0 if Enabled...
May 09 09:47:46 ever10bmc systemd[1]: Starting Updates symlinks for active PNOR version...
May 09 09:47:46 ever10bmc systemd[1]: Starting CFAM reset...
May 09 09:47:46 ever10bmc systemd[1]: op-stop-instructions@0.service: Deactivated successfully.
May 09 09:47:46 ever10bmc systemd[1]: Stopped Stop instructions for host0.
May 09 09:47:46 ever10bmc systemd[1]: Stopped target Stop Host0 (Pre).
May 09 09:47:46 ever10bmc obmc-clear-all-fault-leds-and-remove-crit-association[1457]: Current chassis power state is ,
"xyz.openbmc_project.State.Chassis.PowerState.On". EXIT clear-all-fault-leds.sh SCRIPT SUCCESSFULLY WITHOUT DOING ANY FAULT LED RESET.
May 09 09:47:46 ever10bmc systemd[1]: op-reset-host-clear.service: Deactivated successfully.
May 09 09:47:48 ever10bmc vpd-manager[669]: Setting GPIO: presence-cable-card11 to 1
May 09 09:47:48 ever10bmc systemd[1]: obmc-clear-all-fault-leds-and-remove-crit-association@true.service: Deactivated successfully.
May 09 09:47:48 ever10bmc systemd[1]: Finished Clears all fault LED to true and remove critical associations.
May 09 09:47:48 ever10bmc kernel: at24 26-0051: 8192 byte 24c64 EEPROM, writable, 1 bytes/write

Signed-off-by: Priyanga Ramasamy <priyanga24@in.ibm.com>