### PR TITLE
1020: sdbusplus: object: don't use 'bool' argument constructor

### DIFF
--- a/association_manager.cpp
+++ b/association_manager.cpp
@@ -290,8 +290,8 @@ void Manager::createAssociation(const std::string& forwardPath,
     auto object = _associationIfaces.find(forwardPath);
     if (object == _associationIfaces.end())
     {
-        auto a = std::make_unique<AssociationObject>(_bus, forwardPath.c_str(),
-                                                     true);
+        auto a = std::make_unique<AssociationObject>(
+            _bus, forwardPath.c_str(), AssociationObject::action::defer_emit);
 
         using AssociationProperty =
             std::vector<std::tuple<std::string, std::string, std::string>>;


### PR DESCRIPTION
#### 1020: sdbusplus: object: don't use 'bool' argument constructor
```
`sdbusplus::server::object_t` has long had an enum-based parameter for
signal action, but maintained a backwards compatible boolean mapping.
It is time to remove this boolean to make it more observable which
actions are being used in applications.  Map all `true` occurrences to
`action::defer_emit`.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
Change-Id: I5fd72e2cf82410d41e8342e5ecab96cd87b4cce0
```