### PR TITLE
Pick up Control Host interface

### DIFF
--- a/pimgen.py
+++ b/pimgen.py
@@ -571,7 +571,8 @@ class Everything(Renderer):
 
         for y in yaml_files:
             # parse only phosphor dbus related interface files
-            if not (y.startswith('xyz') or y.startswith('com/ibm/ipzvpd')):
+            if not (y.startswith('xyz') or y.startswith('com/ibm/ipzvpd')
+                    or y.startswith('com/ibm/Control/Host')):
                 continue
             with open(os.path.join(targetdir, y)) as fd:
                 i = y.replace('.interface.yaml', '').replace(os.sep, '.')


### PR DESCRIPTION
This commit enables pimgen.py to pick up
com/ibm/Control/Host interface(s).

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>