### PR TITLE
utils: Fix enum conversion

### DIFF
--- a/utils.hpp
+++ b/utils.hpp
@@ -75,7 +75,6 @@ struct MakeVariantVisitor
     struct Make<
         T, Arg,
         typename std::enable_if_t<
-            !std::is_convertible_v<Arg, T> &&
             std::is_same_v<std::string,
                            std::remove_cv_t<std::remove_reference_t<Arg>>> &&
             sdbusplus::message::has_convert_from_string_v<T>>>


### PR DESCRIPTION
This is just another update to the previous commit based on
more testing that I did.

In certain scenarios, the first template specialization was still
being matched since a string is convertible to
variant<string, enum, ...>.

Signed-off-by: Santosh Puranik <santosh.puranik@in.ibm.com>