### PR TITLE
Add additional variant types to InterfaceVariantType (#11)

### DIFF
--- a/types.hpp
+++ b/types.hpp
@@ -20,7 +20,8 @@ class Manager;
 
 /** @brief Inventory manager supported property types. */
 using InterfaceVariantType =
-    std::variant<bool, size_t, int64_t, std::string, std::vector<uint8_t>>;
+    std::variant<bool, size_t, int64_t, uint16_t, std::string,
+                 std::vector<uint8_t>, std::vector<std::string>>;
 
 template <typename T>
 using InterfaceType = std::map<std::string, T>;


### PR DESCRIPTION
Add uint16 and vector<string> to InterfaceVariantType to support for the Notify D-Bus method.

Signed-off-by: Sagar Srinivas <sagar.srinivas@ibm.com>