### PR TITLE
Reset operational status at start up

### DIFF
--- a/scripts/clear-all-fault-leds.sh
+++ b/scripts/clear-all-fault-leds.sh
@@ -68,11 +68,6 @@ then
         GetSubTreePaths sias "/xyz/openbmc_project/inventory" 0 1 "xyz.openbmc_project.State.Decorator.OperationalStatus" \
         | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line
     do
-        echo "$line" | grep "powersupply\|dimm\|dcm\|fan" >/dev/null
-        rc=$?
-        if [ $rc -eq 0 ]; then
-            continue
-        fi
         busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action";
     done
 else
@@ -80,11 +75,6 @@ else
         GetSubTreePaths sias "/xyz/openbmc_project/inventory" 0 1 "xyz.openbmc_project.State.Decorator.OperationalStatus" \
         | sed  's/ /\n/g' | tail -n+3 | grep -Ev "$excluded_groups" | awk -F "\"" '{print $2}' | while read -r line
     do
-        echo "$line" | grep "powersupply\|dimm\|dcm\|fan" >/dev/null
-        rc=$?
-        if [ $rc -eq 0 ]; then
-            continue
-        fi
         busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action";
     done
 fi


### PR DESCRIPTION
The commit removes special handling w.r.t. re-setting of operational status for some of the FRUs at start up. This is done considering that information related to guard against core and dimms are not available at this point.

To cover the situation where LEDs needs to be light up for guarded FRUs a different script will be trigerred once the service holding guard informationis up.