### PR TITLE
Skip core paths under PLDM while setting status

### DIFF
--- a/scripts/clear-all-fault-leds.sh
+++ b/scripts/clear-all-fault-leds.sh
@@ -68,6 +68,13 @@ then
         GetSubTreePaths sias "/xyz/openbmc_project/inventory" 0 1 "xyz.openbmc_project.State.Decorator.OperationalStatus" \
         | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line
     do
+        #object paths for core implemets interface for operational status but is hosted by PLDM service
+        # not by inventory manager. Hence we need to skip call to those paths.
+        echo "$line" | grep "core" >/dev/null
+        rc=$?
+        if [ $rc -eq 0 ]; then
+            continue;
+        fi
         busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action";
     done
 else
@@ -75,6 +82,13 @@ else
         GetSubTreePaths sias "/xyz/openbmc_project/inventory" 0 1 "xyz.openbmc_project.State.Decorator.OperationalStatus" \
         | sed  's/ /\n/g' | tail -n+3 | grep -Ev "$excluded_groups" | awk -F "\"" '{print $2}' | while read -r line
     do
+        #object paths for core implemets interface for operational status but is hosted by PLDM service
+        # not by inventory manager. Hence we need to skip call to those paths.
+        echo "$line" | grep "core" >/dev/null
+        rc=$?
+        if [ $rc -eq 0 ]; then
+            continue;
+        fi
         busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action";
     done
 fi


### PR DESCRIPTION
Path for cores are hosted by PLDM service and needs to be skipped while setting operational status to clear LEDs. Reason:
Paths under PLDM servcie does not contribute to setting/ unsetting of LEDs.