### PR TITLE
1030:Clear PSU fault led before PSU service executes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -3,7 +3,7 @@ BUILT_SOURCES=generated.cpp extra_ifaces.cpp gen_serialization.hpp
 CLEANFILES=$(BUILT_SOURCES)
 
 bin_PROGRAMS = phosphor-inventory remove-association
-bin_SCRIPTS = scripts/clear-all-fault-leds.sh
+bin_SCRIPTS = scripts/clear-all-fault-leds.sh scripts/clear-psu-fault-leds.sh
 noinst_LTLIBRARIES = libmanagercommon.la libmanager.la
 
 extra_yamldir=$(YAML_PATH)/extra_interfaces.d

--- a/scripts/clear-all-fault-leds.sh
+++ b/scripts/clear-all-fault-leds.sh
@@ -70,7 +70,7 @@ then
     do
         #object paths for core implemets interface for operational status but is hosted by PLDM service
         # not by inventory manager. Hence we need to skip call to those paths.
-        echo "$line" | grep "core" >/dev/null
+        echo "$line" | grep "core\|powersupply" >/dev/null
         rc=$?
         if [ $rc -eq 0 ]; then
             continue;
@@ -84,7 +84,7 @@ else
     do
         #object paths for core implemets interface for operational status but is hosted by PLDM service
         # not by inventory manager. Hence we need to skip call to those paths.
-        echo "$line" | grep "core" >/dev/null
+        echo "$line" | grep "core\|powersupply" >/dev/null
         rc=$?
         if [ $rc -eq 0 ]; then
             continue;

--- a/scripts/clear-psu-fault-leds.sh
+++ b/scripts/clear-psu-fault-leds.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# This shell script clears enclosure fault LED and PSU fault LED.
+
+# Skip running the script if chassis is powered ON.
+current_chassis_status=$(busctl get-property xyz.openbmc_project.State.Chassis /xyz/openbmc_project/state/chassis0 xyz.openbmc_project.State.Chassis CurrentPowerState | cut -d" " -f2)
+
+if [ "${current_chassis_status}" = "\"xyz.openbmc_project.State.Chassis.PowerState.On\"" ]; then
+    echo "Current chassis power state is , $current_chassis_status . Exit clear-psu-fault-leds.sh script successfully without resetting PSU and enclosure fault LEDs."
+    exit 0
+fi
+
+# Explicitly set Asserted to false for enclosure_fault LED group object.
+busctl set-property xyz.openbmc_project.LED.GroupManager "/xyz/openbmc_project/led/groups/enclosure_fault" xyz.openbmc_project.Led.Group Asserted b false;
+
+# Get powersupply objects
+busctl call xyz.openbmc_project.ObjectMapper /xyz/openbmc_project/object_mapper xyz.openbmc_project.ObjectMapper GetSubTreePaths sias "/xyz/openbmc_project/inventory" 0 1 "xyz.openbmc_project.Inventory.Item.PowerSupply" | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line
+do
+    # Clear fault LEDs for all power supply objects by setting its Functional to true.
+    busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b true;
+done
+
+exit 0


### PR DESCRIPTION
This commit creates a new script that clears powersupply units fault leds and enclosure fault leds on BMC reboot and chassis reset conditions.

This script will get triggerred before phosphor-psu-monitor service wakes up, so that any fault which is identified by psu-monitor will not get cleared.

The existing script which clears all fault leds on the system will now skip clearing powersupply fault leds.

Test works as expected.