### PR TITLE
1030: clear SAI on reboot (#28)

### DIFF
--- a/scripts/clear-psu-fault-leds.sh
+++ b/scripts/clear-psu-fault-leds.sh
@@ -10,8 +10,11 @@ if [ "${current_chassis_status}" = "\"xyz.openbmc_project.State.Chassis.PowerSta
     exit 0
 fi
 
-# Explicitly set Asserted to false for enclosure_fault LED group object.
+# Explicitly set Asserted to false for enclosure_fault, SAI, enclosure identify LED group object as these are not to be persisted.
 busctl set-property xyz.openbmc_project.LED.GroupManager "/xyz/openbmc_project/led/groups/enclosure_fault" xyz.openbmc_project.Led.Group Asserted b false;
+busctl set-property xyz.openbmc_project.LED.GroupManager "/xyz/openbmc_project/led/groups/platform_system_attention_indicator" xyz.openbmc_project.Led.Group Asserted b false;
+busctl set-property xyz.openbmc_project.LED.GroupManager "/xyz/openbmc_project/led/groups/partition_system_attention_indicator" xyz.openbmc_project.Led.Group Asserted b false;
+busctl set-property xyz.openbmc_project.LED.GroupManager "/xyz/openbmc_project/led/groups/enclosure_identify" xyz.openbmc_project.Led.Group Asserted b false;
 
 # Get powersupply objects
 busctl call xyz.openbmc_project.ObjectMapper /xyz/openbmc_project/object_mapper xyz.openbmc_project.ObjectMapper GetSubTreePaths sias "/xyz/openbmc_project/inventory" 0 1 "xyz.openbmc_project.Inventory.Item.PowerSupply" | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line


### PR DESCRIPTION
#### clear SAI on reboot (#28)
```
The asserted property for SAI and identofy LED needs to be reset
at every reboot so that in case of any new PELs that require to
trigger SAI, the property can be set and a signal can be emitted
for physical LEDs to behave accordingly.

Signed-off-by: Sunny Srivastava <sunnsr25@in.ibm.com>
```