### PR TITLE
1020: Fix script errors and Update clear-all-fault-leds.sh (#32) & Add explicit Assert for FRU's (#31)

### DIFF
--- a/scripts/clear-all-fault-leds.sh
+++ b/scripts/clear-all-fault-leds.sh
@@ -76,6 +76,15 @@ then
             continue;
         fi
         busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action";
+
+	#Set the Asserted State
+	busctl call xyz.openbmc_project.ObjectMapper "$line/fault_identifying" \
+	org.freedesktop.DBus.Properties Get ss "xyz.openbmc_project.Association" \
+	"endpoints" | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line2
+	do
+	    busctl set-property xyz.openbmc_project.LED.GroupManager \
+	    "$line2" xyz.openbmc_project.Led.Group Asserted b false;
+   	done
     done
 else
     busctl call xyz.openbmc_project.ObjectMapper /xyz/openbmc_project/object_mapper xyz.openbmc_project.ObjectMapper \
@@ -90,6 +99,15 @@ else
             continue;
         fi
         busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action";
+
+	#Set the Asserted State
+	busctl call xyz.openbmc_project.ObjectMapper "$line/fault_identifying" \
+	org.freedesktop.DBus.Properties Get ss "xyz.openbmc_project.Association" \
+	"endpoints" | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line2
+	do
+	    busctl set-property xyz.openbmc_project.LED.GroupManager \
+	    "$line2" xyz.openbmc_project.Led.Group Asserted b false;
+   	done
     done
 fi
 

--- a/scripts/clear-all-fault-leds.sh
+++ b/scripts/clear-all-fault-leds.sh
@@ -68,22 +68,41 @@ then
     GetSubTreePaths sias "/xyz/openbmc_project/inventory" 0 1 "xyz.openbmc_project.State.Decorator.OperationalStatus" \
     | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line
     do
+	#skip All empty lines
+	if [ -z "$line" ];then
+	    continue;
+	fi
+
         #object paths for core implemets interface for operational status but is hosted by PLDM service
         # not by inventory manager. Hence we need to skip call to those paths.
-        echo "$line" | grep "core\|powersupply" >/dev/null
+        echo "$line" | grep "core\|powersupply\|unit\|connector\|chassis1" >/dev/null
         rc=$?
         if [ $rc -eq 0 ]; then
             continue;
         fi
-        busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action";
+        busctl set-property xyz.openbmc_project.Inventory.Manager \
+	"$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action";
 
-	#Set the Asserted State
-	busctl call xyz.openbmc_project.ObjectMapper "$line/fault_identifying" \
+	#skip paths which have no fault LED
+        echo "$line" | grep "pcie_card\|usb\|drive\|ethernet\|fan0_\|fan1_\|fan2_\|fan3_\|fan4_\|fan5_\|rdx\|cables\|displayport\|pcieslot12" >/dev/null
+        rc=$?
+        if [ $rc -eq 0 ]; then
+            continue;
+        fi
+
+	# Get the Fault LED associations
+	busctl call xyz.openbmc_project.ObjectMapper "$line/fault_led_group" \
 	org.freedesktop.DBus.Properties Get ss "xyz.openbmc_project.Association" \
 	"endpoints" | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line2
 	do
+	    # Skip All empty lines
+	    if [ -z "$line2" ];then
+	        continue;
+	    fi
+
+	    # Set the Asserted State property
 	    busctl set-property xyz.openbmc_project.LED.GroupManager \
-	    "$line2" xyz.openbmc_project.Led.Group Asserted b false;
+		    "$line2" xyz.openbmc_project.Led.Group Asserted b false;
    	done
     done
 else
@@ -91,20 +110,39 @@ else
     GetSubTreePaths sias "/xyz/openbmc_project/inventory" 0 1 "xyz.openbmc_project.State.Decorator.OperationalStatus" \
     | sed  's/ /\n/g' | tail -n+3 | grep -Ev "$excluded_groups" | awk -F "\"" '{print $2}' | while read -r line
     do
+	# Skip All empty lines
+	if [ -z "$line" ];then
+	    continue;
+	fi
+
         #object paths for core implemets interface for operational status but is hosted by PLDM service
         # not by inventory manager. Hence we need to skip call to those paths.
-        echo "$line" | grep "core\|powersupply" >/dev/null
+        echo "$line" | grep "core\|powersupply\|unit\|connector\|chassis1" >/dev/null
         rc=$?
         if [ $rc -eq 0 ]; then
             continue;
         fi
-        busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action";
+        busctl set-property xyz.openbmc_project.Inventory.Manager \
+		"$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action";
 
-	#Set the Asserted State
-	busctl call xyz.openbmc_project.ObjectMapper "$line/fault_identifying" \
+	#s Skip paths which have no fault LED
+        echo "$line" | grep "pcie_card\|usb\|drive\|ethernet\|fan0_\|fan1_\|fan2_\|fan3_\|fan4_\|fan5_\|rdx\|cables\|displayport\|pcieslot12" >/dev/null
+        rc=$?
+        if [ $rc -eq 0 ]; then
+            continue;
+        fi
+
+	# Get the Fault LED associations
+	busctl call xyz.openbmc_project.ObjectMapper "$line/fault_led_group" \
 	org.freedesktop.DBus.Properties Get ss "xyz.openbmc_project.Association" \
 	"endpoints" | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line2
 	do
+	    # Skip All empty lines
+	    if [ -z "$line2" ];then
+	        continue;
+	    fi
+
+	    # Set the Asserted State property
 	    busctl set-property xyz.openbmc_project.LED.GroupManager \
 	    "$line2" xyz.openbmc_project.Led.Group Asserted b false;
    	done

--- a/scripts/clear-psu-fault-leds.sh
+++ b/scripts/clear-psu-fault-leds.sh
@@ -21,6 +21,14 @@ busctl call xyz.openbmc_project.ObjectMapper /xyz/openbmc_project/object_mapper 
 do
     # Clear fault LEDs for all power supply objects by setting its Functional to true.
     busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b true;
-done
 
+    #Set the Asserted State
+    busctl call xyz.openbmc_project.ObjectMapper "$line/fault_identifying" \
+    org.freedesktop.DBus.Properties Get ss "xyz.openbmc_project.Association" \
+    "endpoints" | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line2
+    do
+        busctl set-property xyz.openbmc_project.LED.GroupManager \
+        "$line2" xyz.openbmc_project.Led.Group Asserted b false;
+    done
+done
 exit 0

--- a/scripts/clear-psu-fault-leds.sh
+++ b/scripts/clear-psu-fault-leds.sh
@@ -23,7 +23,7 @@ do
     busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b true;
 
     #Set the Asserted State
-    busctl call xyz.openbmc_project.ObjectMapper "$line/fault_identifying" \
+    busctl call xyz.openbmc_project.ObjectMapper "$line/fault_led_group" \
     org.freedesktop.DBus.Properties Get ss "xyz.openbmc_project.Association" \
     "endpoints" | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line2
     do


### PR DESCRIPTION
#### Fix script errors and Update clear-all-fault-leds.sh (#32)
```
* Fix script errors

  Add empty line check and skip when encountered
  Skip assering objects which do not have fault group
  Skip setting LED fro units and connectors
  Skip setting LED for MEX as not controlled by bmc
  Association modified as per release branch
Signed-off-by: jinuthomas <jinu.joy.thomas@in.ibm.com>

* Update clear-all-fault-leds.sh

---------

Signed-off-by: jinuthomas <jinu.joy.thomas@in.ibm.com>
```
#### Add explicit Assert for FRU's (#31)
```
Set assert property to default similar to operational status
  Set for all FRUs and so both scripts are modified

Signed-off-by: jinuthomas <jinu.joy.thomas@in.ibm.com>```