### PR TITLE
Update script to handle error gracefully

### DIFF
--- a/scripts/clear-all-fault-leds.sh
+++ b/scripts/clear-all-fault-leds.sh
@@ -3,7 +3,7 @@
 # This shell script sets the group D-Bus objects in
 # /xyz/openbmc_project/State/Decorator/OperationalStatusManager
 # to true or false.
-set -e
+
 usage()
 {
     echo "clear-all-fault-leds.sh [true/false]"


### PR DESCRIPTION
Option "set -e" has been removed from the script to avoid exiting the script in case any command returns a non-zero exit status.