### PR TITLE
Notify PIM to update functional property

### DIFF
--- a/scripts/clear-all-fault-leds.sh
+++ b/scripts/clear-all-fault-leds.sh
@@ -79,8 +79,13 @@ then
         if [ $rc -eq 0 ]; then
             continue;
         fi
-        busctl set-property xyz.openbmc_project.Inventory.Manager \
-            "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action"
+
+        echo "$line" | grep "/xyz/openbmc_project/inventory" >/dev/null
+        rc=$?
+        if [ $rc -eq 0 ]; then
+            inventory_path=$(echo "$line" | sed 's|/xyz/openbmc_project/inventory||')
+            busctl call xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory xyz.openbmc_project.Inventory.Manager Notify a\{oa\{sa\{sv\}\}\} 1 "$inventory_path" 1 "xyz.openbmc_project.State.Decorator.OperationalStatus" 1 "Functional" b "$action";
+        fi
 
         #skip paths which have no fault LED
         echo "$line" | grep "pcie_card\|usb\|drive\|ethernet\|fan0_\|fan1_\|fan2_\|fan3_\|fan4_\|fan5_\|rdx\|cables\|displayport\|pcieslot12" >/dev/null
@@ -121,10 +126,15 @@ else
         if [ $rc -eq 0 ]; then
             continue;
         fi
-        busctl set-property xyz.openbmc_project.Inventory.Manager \
-            "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b "$action"
 
-        # Skip paths which have no fault LED
+        echo "$line" | grep "/xyz/openbmc_project/inventory" >/dev/null
+        rc=$?
+        if [ $rc -eq 0 ]; then
+            inventory_path=$(echo "$line" | sed 's|/xyz/openbmc_project/inventory||')
+            busctl call xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory xyz.openbmc_project.Inventory.Manager Notify a\{oa\{sa\{sv\}\}\} 1 "$inventory_path" 1 "xyz.openbmc_project.State.Decorator.OperationalStatus" 1 "Functional" b "$action";
+        fi
+
+        #s Skip paths which have no fault LED
         echo "$line" | grep "pcie_card\|usb\|drive\|ethernet\|fan0_\|fan1_\|fan2_\|fan3_\|fan4_\|fan5_\|rdx\|cables\|displayport\|pcieslot12" >/dev/null
         rc=$?
         if [ $rc -eq 0 ]; then

--- a/scripts/clear-psu-fault-leds.sh
+++ b/scripts/clear-psu-fault-leds.sh
@@ -20,15 +20,22 @@ busctl set-property xyz.openbmc_project.LED.GroupManager "/xyz/openbmc_project/l
 busctl call xyz.openbmc_project.ObjectMapper /xyz/openbmc_project/object_mapper xyz.openbmc_project.ObjectMapper GetSubTreePaths sias "/xyz/openbmc_project/inventory" 0 1 "xyz.openbmc_project.Inventory.Item.PowerSupply" | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line
 do
     # Clear fault LEDs for all power supply objects by setting its Functional to true.
-    busctl set-property xyz.openbmc_project.Inventory.Manager "$line" xyz.openbmc_project.State.Decorator.OperationalStatus Functional b true;
+    echo "$line" | grep "/xyz/openbmc_project/inventory" >/dev/null
+    rc=$?
+    if [ $rc -eq 0 ]; then
+        inventory_path=$(echo "$line" | sed 's|/xyz/openbmc_project/inventory||')
+        busctl call xyz.openbmc_project.Inventory.Manager /xyz/openbmc_project/inventory xyz.openbmc_project.Inventory.Manager Notify "a{oa{sa{sv}}}" 1 "$inventory_path" 1 "xyz.openbmc_project.State.Decorator.OperationalStatus" 1 "Functional" b true;
+    fi
 
     #Set the Asserted State
     busctl call xyz.openbmc_project.ObjectMapper "$line/fault_identifying" \
         org.freedesktop.DBus.Properties Get ss "xyz.openbmc_project.Association" \
         "endpoints" | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line2
     do
-        busctl set-property xyz.openbmc_project.LED.GroupManager \
-            "$line2" xyz.openbmc_project.Led.Group Asserted b false;
+        if [ -n "$line2" ]; then
+            busctl set-property xyz.openbmc_project.LED.GroupManager \
+                "$line2" xyz.openbmc_project.Led.Group Asserted b false;
+        fi
     done
 done
 exit 0


### PR DESCRIPTION
During power-on, clear fault-leds scripts clears all the fault leds by setting the functional property of the corresponding led FRU to true. While setting the property, it calls the busctl set-property method, which updates the data only on DBus and data is not persisted.

When BMC is rebooted while host is running, on system come back, the stale data of the FRU which has functional as false will get updated on the DBus, which marks that FRU as critical on ASMI.