### PR TITLE
Fix:External chassis is not shown on GUI #705401

### DIFF
--- a/scripts/clear-all-fault-leds.sh
+++ b/scripts/clear-all-fault-leds.sh
@@ -74,7 +74,7 @@ then
 
         #object paths for core implemets interface for operational status but is hosted by PLDM service
         # not by inventory manager. Hence we need to skip call to those paths.
-        echo "$line" | grep "core\|powersupply\|unit\|connector\|chasis1" >/dev/null
+        echo "$line" | grep "core\|powersupply\|unit\|connector\|chassis[0-9]" >/dev/null
         rc=$?
         if [ $rc -eq 0 ]; then
             continue;
@@ -121,7 +121,7 @@ else
 
         #object paths for core implemets interface for operational status but is hosted by PLDM service
         # not by inventory manager. Hence we need to skip call to those paths.
-        echo "$line" | grep "core\|powersupply\|unit\|connector\|chassis1" >/dev/null
+        echo "$line" | grep "core\|powersupply\|unit\|connector\|chassis[0-9]" >/dev/null
         rc=$?
         if [ $rc -eq 0 ]; then
             continue;

--- a/scripts/clear-psu-fault-leds.sh
+++ b/scripts/clear-psu-fault-leds.sh
@@ -19,6 +19,13 @@ busctl set-property xyz.openbmc_project.LED.GroupManager "/xyz/openbmc_project/l
 # Get powersupply objects
 busctl call xyz.openbmc_project.ObjectMapper /xyz/openbmc_project/object_mapper xyz.openbmc_project.ObjectMapper GetSubTreePaths sias "/xyz/openbmc_project/inventory" 0 1 "xyz.openbmc_project.Inventory.Item.PowerSupply" | sed  's/ /\n/g' | tail -n+3 | awk -F "\"" '{print $2}' | while read -r line
 do
+    #object paths for external chassis is hosted by PLDM service not by inventory manager. Hence we need to skip those paths.
+    echo "$line" | grep -E "chassis[0-9]+" >/dev/null
+    rc=$?
+    if [ $rc -eq 0 ]; then
+        continue;
+    fi
+
     # Clear fault LEDs for all power supply objects by setting its Functional to true.
     echo "$line" | grep "/xyz/openbmc_project/inventory" >/dev/null
     rc=$?


### PR DESCRIPTION
External chassis connected to the system is not shown on the ASMI page. This happens when PSU fault LEDs script executed after PLDM service comes up.

PSU script finds and publishes external chassis info on the Dbus under PIM. On next subsequent booting, PLDM service avoids publishing chassis path on DBus as it already finds chassis path under the PIM, hence external chassis is not shown on the ASMI page.

Changes are made in this commit to fix above issue, where in PSU script avoided updating of external chassis on DBus as it is handled by PLDM service.

This commit also corrects chassis spelling in the clear all fault LED script.