### PR TITLE
Remove external chassis hosted under PIM #713080

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -136,7 +136,7 @@ executable(
     install_dir: get_option('bindir'),
 )
 
-install_data(['scripts/clear-all-fault-leds.sh', 'scripts/clear-psu-fault-leds.sh'],
+install_data(['scripts/clear-all-fault-leds.sh', 'scripts/clear-psu-fault-leds.sh', 'scripts/clear-external-chassis.sh'],
     install_mode: 'rwxr-xr-x',
     install_dir: get_option('bindir')
 )

--- a/scripts/clear-external-chassis.sh
+++ b/scripts/clear-external-chassis.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+# Remove if external chassis persist path(s) hosted under phosphor-inventory-manager
+external_chassis_pim_path="/var/lib/phosphor-inventory-manager/xyz/openbmc_project/inventory/system/chassis"
+
+# Find and delete directories matching pattern
+for dir in "${external_chassis_pim_path}"[0-9]*; do
+    if [ -d "$dir" ]; then
+        echo "Removing external chassis directory: $dir"
+        rm -rf "$dir"
+    fi
+done


### PR DESCRIPTION
External chassis path is published under the phosphor-inventory-manager service, which should have been published under PLDM service. This issue is created by the LED scripts where PIM persists call is made to update operational status but missed excluding external chassis path.

This commit adds the script to remove external chassis path hosted under phosphor-inventory-manager service.