### PR TITLE
Remove external chassis hosted under PIM #705401

### DIFF
--- a/clear_external_chassis.cpp
+++ b/clear_external_chassis.cpp
@@ -1,0 +1,44 @@
+#include <filesystem>
+#include <iostream>
+#include <regex>
+
+int main()
+{
+    try
+    {
+        std::string pimPath =
+            "/var/lib/phosphor-inventory-manager/xyz/openbmc_project/inventory/system";
+        std::regex chassisFolderName(R"(chassis[0-9]+)");
+
+        for (const auto& entry : std::filesystem::directory_iterator(pimPath))
+        {
+            if (entry.is_directory())
+            {
+                std::string folderName = entry.path().filename().string();
+
+                if (std::regex_match(folderName, chassisFolderName))
+                {
+                    std::filesystem::path folderPath = entry.path();
+                    std::cout << "clear-external-chassis, Removing Directory: "
+                              << folderPath << std::endl;
+                    std::error_code ec;
+                    std::filesystem::remove_all(folderPath, ec);
+
+                    if (ec)
+                    {
+                        std::cerr << "Error removing " << folderPath << ": "
+                                  << ec.message() << std::endl;
+                    }
+                }
+            }
+        }
+    }
+    catch (std::exception& ex)
+    {
+        std::cerr
+            << "Exception occured while checking & cleaning any exetrnal chassis: "
+            << ex.what() << std::endl;
+    }
+
+    return 0;
+}

--- a/meson.build
+++ b/meson.build
@@ -136,6 +136,14 @@ executable(
     install_dir: get_option('bindir'),
 )
 
+executable(
+    'clear-external-chassis',
+    'clear_external_chassis.cpp',
+    implicit_include_directories: true,
+    install: true,
+    install_dir: get_option('bindir'),
+)
+
 install_data(['scripts/clear-all-fault-leds.sh', 'scripts/clear-psu-fault-leds.sh'],
     install_mode: 'rwxr-xr-x',
     install_dir: get_option('bindir')


### PR DESCRIPTION
External chassis path is published under the phosphor-inventory-manager service, which should have been published under PLDM service. This issue is created by the LED scripts where PIM persists call is made to update operational status but missed excluding external chassis path.

This commit adds the script to remove external chassis path hosted under phosphor-inventory-manager service.